### PR TITLE
118 indexacao banco performance

### DIFF
--- a/src/infra/init/04_schema_exames.sql
+++ b/src/infra/init/04_schema_exames.sql
@@ -15,3 +15,7 @@ CREATE TABLE IF NOT EXISTS public.exames (
     ON DELETE NO ACTION
     ON UPDATE NO ACTION
 );
+
+CREATE INDEX IF NOT EXISTS idx_exames_usuario
+  ON public.exames (id_usuario);
+

--- a/src/infra/init/04_schema_exames.sql
+++ b/src/infra/init/04_schema_exames.sql
@@ -19,3 +19,6 @@ CREATE TABLE IF NOT EXISTS public.exames (
 CREATE INDEX IF NOT EXISTS idx_exames_usuario
   ON public.exames (id_usuario);
 
+CREATE INDEX IF NOT EXISTS idx_exames_modulo
+  ON public.exames (id_modulo)  
+

--- a/src/infra/init/04_schema_exames.sql
+++ b/src/infra/init/04_schema_exames.sql
@@ -20,7 +20,7 @@ CREATE INDEX IF NOT EXISTS idx_exames_usuario
   ON public.exames (id_usuario);
 
 CREATE INDEX IF NOT EXISTS idx_exames_modulo
-  ON public.exames (id_modulo)  
+  ON public.exames (id_modulo);  
 
 CREATE INDEX IF NOT EXISTS idx_exames_usuario_modulo
-  ON public.exames (id_usuario, id_modulo)
+  ON public.exames (id_usuario, id_modulo);

--- a/src/infra/init/04_schema_exames.sql
+++ b/src/infra/init/04_schema_exames.sql
@@ -22,3 +22,5 @@ CREATE INDEX IF NOT EXISTS idx_exames_usuario
 CREATE INDEX IF NOT EXISTS idx_exames_modulo
   ON public.exames (id_modulo)  
 
+CREATE INDEX IF NOT EXISTS idx_exames_usuario_modulo
+  ON public.exames (id_usuario, id_modulo)

--- a/src/infra/init/05_schema_respostas.sql
+++ b/src/infra/init/05_schema_respostas.sql
@@ -24,4 +24,4 @@ CREATE INDEX IF NOT EXISTS idx_respostas_questao
   ON public.respostas (id_questao);
 
 CREATE INDEX IF NOT EXISTS idx_resposta_exame_questao
-  ON public.respostas (id_exame, id_questao)
+  ON public.respostas (id_exame, id_questao);

--- a/src/infra/init/05_schema_respostas.sql
+++ b/src/infra/init/05_schema_respostas.sql
@@ -22,3 +22,6 @@ CREATE INDEX IF NOT EXISTS idx_respostas_exame
 
 CREATE INDEX IF NOT EXISTS idx_respostas_questao
   ON public.respostas (id_questao);
+
+CREATE INDEX IF NOT EXISTS idx_resposta_exame_questao
+  ON public.respostas (id_exame, id_questao)


### PR DESCRIPTION
-- Commit 1 --
Foi adicionado o índice idx_exames_usuario na tabela exames na coluna id_usuario, pois as consultas de progresso sempre filtram por usuário, tornando essa coluna a mais acessada nas buscas.

-- Commit 2 --
Foi adicionado o índice idx_exames_modulo na tabela exames na coluna id_modulo, para otimizar buscas de progresso filtradas por módulo específico.

-- Commit 3 --
Foi adicionado o índice composto idx_exames_usuario_modulo na tabela exames com as colunas id_usuario e id_modulo, pois consultas de progresso geralmente filtram por usuário e módulo ao mesmo tempo.

-- Commit 4 --
Foi adicionado o índice composto idx_resposta_exame_questao na tabela respostas com as colunas id_exame e id_questao, para otimizar a busca de todas as respostas de um exame específico.

-- Commit 5 e 6 --
Adiciona somente uma correção na escrita do código.